### PR TITLE
Fix null safety in RestPostExperimentAction and update test expectations

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPostExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPostExperimentAction.java
@@ -62,7 +62,8 @@ public class RestPostExperimentAction extends BaseRestHandler {
 
         String querySetId = (String) source.get("querySetId");
         List<String> searchConfigurationList = ParserUtils.convertObjToList(source, "searchConfigurationList");
-        int size = (Integer) source.get("size");
+        Integer sizeObj = (Integer) source.get("size");
+        int size = sizeObj != null ? sizeObj.intValue() : 10; // Default size to 10 if not provided
         List<String> judgmentList = ParserUtils.convertObjToList(source, "judgmentList");
 
         List<Map<String, Object>> evaluationResultList = ParserUtils.convertObjToListOfMaps(source, "evaluationResultList");

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -174,7 +174,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     }
 
     public void testTotalRestHandlers() {
-        assertEquals(14, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
+        assertEquals(15, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
     }
 
     public void testQuerySetTransportIsAdded() {


### PR DESCRIPTION
- Add null checking for 'size' parameter in RestPostExperimentAction with default value of 10
- Update SearchRelevancePluginTests to expect 15 REST handlers instead of 14
- Fixes NullPointerException when size parameter is not provided in experiment requests

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
